### PR TITLE
Created new screens that use different API endpoints as well as the correspodning test for the screens

### DIFF
--- a/__tests__/PlayerDetail.screen.test.tsx
+++ b/__tests__/PlayerDetail.screen.test.tsx
@@ -1,0 +1,100 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { Image } from "react-native";
+
+// Mock expo-router:
+// - provide a tag param
+// - stub Stack.Screen so it doesn't crash in tests
+jest.mock("expo-router", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    useLocalSearchParams: () => ({ tag: "%23ABC123" }), // "#ABC123" URL-encoded
+    Stack: {
+      Screen: (props: any) => <View {...props} />,
+    },
+  };
+});
+
+// Minimal player payload your component expects
+const mockPlayer = {
+  tag: "#ABC123",
+  name: "Pro One",
+  trophies: 8000,
+  clan: { name: "Legends" },
+  currentDeck: [
+    {
+      id: 26000021,
+      name: "Hog Rider",
+      iconUrls: {
+        medium:
+          "https://api-assets.clashroyale.com/cards/300/Ubu0oUl8tZkusnkZf8Xv9Vno5IO29Y-jbZ4fhoNJ5oc.png",
+      },
+    },
+    {
+      id: 28000000,
+      name: "Fireball",
+      iconUrls: {
+        medium:
+          "https://api-assets.clashroyale.com/cards/300/lZD9MILQv7O-P3XBr_xOLS5idwuz3_7Ws9G60U36yhc.png",
+      },
+    },
+  ],
+};
+
+function makePlayerOk() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => JSON.stringify(mockPlayer),
+  } as Response;
+}
+
+function makeHttpError() {
+  return {
+    ok: false,
+    status: 404,
+    statusText: "Not Found",
+    text: async () => JSON.stringify({ message: "not found" }),
+  } as Response;
+}
+
+describe("PlayerDetail", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue(makePlayerOk());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads and displays player profile + deck images", async () => {
+    const PlayerScreen = require("../app/player/[tag]").default;
+    const { findByText, UNSAFE_getAllByType } = render(<PlayerScreen />);
+
+    // Wait for name to appear
+    expect(await findByText("Pro One")).toBeTruthy();
+
+    // Deck section title exists
+    expect(await findByText(/Current Deck/i)).toBeTruthy();
+
+    // Count <Image/> components directly (no need for testID changes)
+    const images = UNSAFE_getAllByType(Image);
+    expect(images.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows error UI on HTTP failure", async () => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue(makeHttpError());
+
+    const PlayerScreen = require("../app/player/[tag]").default;
+    const { findByText } = render(<PlayerScreen />);
+
+    // Your screen text is "Failed to load player" (not "Error")
+    expect(await findByText(/Failed to load player/i)).toBeTruthy();
+  });
+});
+
+

--- a/__tests__/TopPlayers.screen.test.tsx
+++ b/__tests__/TopPlayers.screen.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// Use a mock variable name Jest allows inside the mock factory
+const mockPush = jest.fn();
+
+// Mock expo-router BEFORE requiring the component
+jest.mock("expo-router", () => {
+  const React = require("react");
+  return {
+    // hook-style router
+    useRouter: () => ({ push: mockPush }),
+
+    // singleton router (covers `import { router } from "expo-router"`)
+    router: { push: mockPush },
+
+    // stub Link so it doesn’t crash if used
+    Link: ({ children }: any) =>
+      typeof children === "function" ? children({}) : children ?? null,
+  };
+});
+
+// Helper: one good response with a single player
+function makePlayersOk() {
+  const body = {
+    items: [
+      {
+        tag: "#ABC123",
+        name: "Pro One",
+        rank: 1,
+        trophies: 8000,
+        clan: { name: "Legends" },
+      },
+    ],
+  };
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+// Helper: an error HTTP response
+function makeHttpError() {
+  return {
+    ok: false,
+    status: 403,
+    statusText: "Forbidden",
+    text: async () => JSON.stringify({ message: "nope" }),
+  } as Response;
+}
+
+describe("TopPlayersScreen", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue(makePlayersOk());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a player and navigates to player detail when tapped", async () => {
+    // require AFTER mocks are set up
+    const TopPlayersScreen = require("../app/(tabs)/topPlayers").default;
+
+    const { findByText, getByText } = render(<TopPlayersScreen />);
+
+    // Wait for player row
+    const row = await findByText("Pro One");
+    expect(row).toBeTruthy();
+
+    // Tap the row (pressing the Text is fine here)
+    fireEvent.press(getByText("Pro One"));
+
+    // Should push to encoded path
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/player/%23ABC123");
+    });
+  });
+
+  it("shows error UI on HTTP failure", async () => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue(makeHttpError());
+
+    const TopPlayersScreen = require("../app/(tabs)/topPlayers").default;
+    const { findByText } = render(<TopPlayersScreen />);
+
+    // Your screen shows "Error" heading when fetch fails
+    expect(await findByText(/Error/i)).toBeTruthy();
+  });
+});
+
+
+

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ export default function TabsLayout() {
       <Tabs.Screen name="landingPage" options={{ headerTitle: 'Home' }} />
       <Tabs.Screen name="cardsPage" options={{ headerTitle: 'Cards' }} />
       <Tabs.Screen name="index" options={{ href: null }} />
+      <Tabs.Screen name="topPlayers" options={{ headerTitle: 'Top Players' }} />
     </Tabs>
   );
 }

--- a/app/(tabs)/cardsPage.tsx
+++ b/app/(tabs)/cardsPage.tsx
@@ -1,7 +1,3 @@
-
-import React, { useEffect, useState } from 'react';
-import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
-
 import { View, Text, StyleSheet, TextInput, Button, Image, ScrollView } from 'react-native';
 import React, {useEffect, useState} from 'react';
 import { Dropdown } from 'react-native-element-dropdown';
@@ -54,8 +50,6 @@ const elixirs = [
 const CardsScreen = () => {
 
     // Enter your own api key inside of this apikey variable
-
-    const apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6ImJiOTU5ZWViLTQ2YzAtNGI3NS1iYjdkLTBkMTRiNzg2ZjIxNCIsImlhdCI6MTc1ODA1MTIzNiwic3ViIjoiZGV2ZWxvcGVyLzY5MzY3ODE2LTM2YjctYTMzYy0zNzY5LTE5NmMyNDcyYTc3MSIsInNjb3BlcyI6WyJyb3lhbGUiXSwibGltaXRzIjpbeyJ0aWVyIjoiZGV2ZWxvcGVyL3NpbHZlciIsInR5cGUiOiJ0aHJvdHRsaW5nIn0seyJjaWRycyI6WyIxOTguMTg5LjI0OS43MyIsIjE3NC44NS45OS4xNjkiXSwidHlwZSI6ImNsaWVudCJ9XX0.7J0lte_XOk25woxuxAzBqrylSQcBVr2cSz4pD1Wr4f1-qAUvU4qlBpTDeq1ZJ3ZdweAzlaLAQHVLpQUiGQ4CpA";
 
     const apiKey = "Enter Api Key Here";
 

--- a/app/(tabs)/cardsPage.tsx
+++ b/app/(tabs)/cardsPage.tsx
@@ -1,5 +1,5 @@
-import { View, Text, StyleSheet, TextInput, Button, Image, ScrollView } from 'react-native'
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState } from 'react';
+import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 // This interface is created in order to store the api's response inside of an array of type Card
 interface Card{
@@ -19,7 +19,7 @@ interface Card{
 const CardsScreen = () => {
 
     // Enter your own api key inside of this apikey variable
-    const apiKey = "Enter api key here";
+    const apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6ImJiOTU5ZWViLTQ2YzAtNGI3NS1iYjdkLTBkMTRiNzg2ZjIxNCIsImlhdCI6MTc1ODA1MTIzNiwic3ViIjoiZGV2ZWxvcGVyLzY5MzY3ODE2LTM2YjctYTMzYy0zNzY5LTE5NmMyNDcyYTc3MSIsInNjb3BlcyI6WyJyb3lhbGUiXSwibGltaXRzIjpbeyJ0aWVyIjoiZGV2ZWxvcGVyL3NpbHZlciIsInR5cGUiOiJ0aHJvdHRsaW5nIn0seyJjaWRycyI6WyIxOTguMTg5LjI0OS43MyIsIjE3NC44NS45OS4xNjkiXSwidHlwZSI6ImNsaWVudCJ9XX0.7J0lte_XOk25woxuxAzBqrylSQcBVr2cSz4pD1Wr4f1-qAUvU4qlBpTDeq1ZJ3ZdweAzlaLAQHVLpQUiGQ4CpA";
     
     // Url used to fetch all the cards in the api request
     const url = "https://api.clashroyale.com/v1/cards";

--- a/app/(tabs)/topPlayers.tsx
+++ b/app/(tabs)/topPlayers.tsx
@@ -1,0 +1,198 @@
+import { router, type Href } from "expo-router";
+import React, { useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import RNPickerSelect from "react-native-picker-select";
+
+type Clan = { name?: string; tag?: string };
+type Player = { tag: string; name: string; rank: number; trophies: number; clan?: Clan };
+type Season = { id: string; startTime?: string; endTime?: string; isActive?: boolean };
+
+// 🔑 put your key here or import from a shared config
+const apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6ImJiOTU5ZWViLTQ2YzAtNGI3NS1iYjdkLTBkMTRiNzg2ZjIxNCIsImlhdCI6MTc1ODA1MTIzNiwic3ViIjoiZGV2ZWxvcGVyLzY5MzY3ODE2LTM2YjctYTMzYy0zNzY5LTE5NmMyNDcyYTc3MSIsInNjb3BlcyI6WyJyb3lhbGUiXSwibGltaXRzIjpbeyJ0aWVyIjoiZGV2ZWxvcGVyL3NpbHZlciIsInR5cGUiOiJ0aHJvdHRsaW5nIn0seyJjaWRycyI6WyIxOTguMTg5LjI0OS43MyIsIjE3NC44NS45OS4xNjkiXSwidHlwZSI6ImNsaWVudCJ9XX0.7J0lte_XOk25woxuxAzBqrylSQcBVr2cSz4pD1Wr4f1-qAUvU4qlBpTDeq1ZJ3ZdweAzlaLAQHVLpQUiGQ4CpA";
+
+export default function TopPlayersScreen() {
+  const H = useMemo(
+    () => ({
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    }),
+    []
+  );
+
+  // --- seasons picker (only working seasons) ---
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [selectedSeason, setSelectedSeason] = useState<string>("2022-09"); // default to last reliable
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("https://api.clashroyale.com/v1/locations/global/seasons", { headers: H });
+        const txt = await res.text();
+        if (!res.ok) throw new Error(txt);
+        const json = JSON.parse(txt);
+        const items: Season[] = Array.isArray(json?.items) ? json.items : [];
+
+        // keep only seasons <= 2022-09 (API newer ones broken)
+        const allowed = items
+          .map(s => s.id)
+          .filter((id: string) => typeof id === "string" && id <= "2022-09")
+          .sort(); // ascending
+
+        setSeasons(allowed.map(id => ({ id } as Season)));
+        if (!allowed.includes(selectedSeason)) setSelectedSeason(allowed.at(-1) ?? "2022-09");
+      } catch (_) {
+        setSeasons([{ id: "2022-09" }]);
+      }
+    })();
+  }, [H]);
+
+  // --- players for chosen season ---
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const url = `https://api.clashroyale.com/v1/locations/global/seasons/${selectedSeason}/rankings/players?limit=50`;
+        const res = await fetch(url, { headers: H });
+        const txt = await res.text();
+        if (cancelled) return;
+        if (!res.ok) throw new Error(txt);
+        const json = JSON.parse(txt);
+        const items: Player[] = Array.isArray(json?.items) ? json.items : [];
+        setPlayers(items);
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(String(e?.message || e));
+          setPlayers([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [H, selectedSeason]);
+
+  // --- tap handler: navigate with a simple string path ---
+  function goToPlayer(rawTag: string) {
+  const tag = rawTag.startsWith("#") ? rawTag : `#${rawTag}`;
+  const href = `/player/${encodeURIComponent(tag)}`;
+  router.push(href as Href);
+}
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Top Players</Text>
+
+      <View style={styles.pickerRow}>
+        <Text style={styles.pickerLabel}>Season:</Text>
+        <RNPickerSelect
+          onValueChange={(v) => v && setSelectedSeason(v)}
+          value={selectedSeason}
+          items={seasons.map((s) => ({ label: s.id, value: s.id }))}
+          useNativeAndroidPickerStyle={false}
+          style={{
+            inputIOS: styles.pickerInput,
+            inputAndroid: styles.pickerInput,
+            iconContainer: { right: 10, top: 10 },
+          }}
+          placeholder={{}}
+        />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator />
+          <Text style={styles.dim}>Loading…</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.center}>
+          <Text style={styles.error}>Error</Text>
+          <Text style={styles.dim}>{error}</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={players}
+          keyExtractor={(p) => p.tag}
+          contentContainerStyle={{ padding: 12 }}
+          renderItem={({ item }) => (
+            <Pressable onPress={() => goToPlayer(item.tag)} style={styles.row}>
+              <View style={styles.rankBadge}>
+                <Text style={styles.rankText}>{item.rank}</Text>
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.name}>{item.name}</Text>
+                <Text style={styles.subtle}>
+                  {item.trophies} 🏆 • {item.clan?.name ?? "No clan"}
+                </Text>
+              </View>
+            </Pressable>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  header: {
+    textAlign: "center",
+    fontSize: 20,
+    fontWeight: "700",
+    paddingVertical: 12,
+    backgroundColor: "#111827",
+    color: "white",
+  },
+  center: { padding: 16, alignItems: "center", justifyContent: "center" },
+  dim: { color: "#6B7280", marginTop: 8 },
+  error: { color: "#DC2626", fontWeight: "700", marginTop: 8 },
+
+  pickerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e5e7eb",
+    backgroundColor: "#fff",
+  },
+  pickerLabel: { fontWeight: "600", marginRight: 8 },
+  pickerInput: {
+    fontSize: 16,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 10,
+  },
+
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: "#F3F4F6",
+    marginBottom: 10,
+  },
+  rankBadge: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "#3B82F6",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  rankText: { color: "white", fontWeight: "700" },
+  name: { fontSize: 16, fontWeight: "700" },
+  subtle: { color: "#374151", marginTop: 2 },
+});
+
+

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,9 +8,12 @@ export default function RootLayout() {
       <Stack.Screen name="login" />
       <Stack.Screen name="signup" />
 
+      {/* detail screen outside the tabs */}
+      <Stack.Screen name="player/[tag]" options={{ title: "Player", headerShown: true }} />
+
+
       {/* Main app (inside tabs group) */}
       <Stack.Screen name="(tabs)" />
     </Stack>
   );  
-
 }

--- a/app/player/[tag].tsx
+++ b/app/player/[tag].tsx
@@ -1,0 +1,225 @@
+// app/player/[tag].tsx
+import { Stack, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, View } from "react-native";
+
+type Arena = { id: number; name: string };
+type Clan = { name?: string };
+type CardIconUrls = { medium?: string; evolutionMedium?: string };
+type Card = { id: number; name: string; iconUrls?: CardIconUrls };
+type SeasonLite = { id?: string; trophies?: number; bestTrophies?: number };
+
+type Player = {
+  tag: string;
+  name: string;
+  trophies: number;
+  bestTrophies?: number;
+  expLevel?: number;
+  clan?: Clan;
+  arena?: Arena;
+  leagueStatistics?: {
+    currentSeason?: SeasonLite;
+    previousSeason?: SeasonLite;
+    bestSeason?: SeasonLite;
+  };
+  currentDeck?: Card[];
+};
+
+const apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6ImJiOTU5ZWViLTQ2YzAtNGI3NS1iYjdkLTBkMTRiNzg2ZjIxNCIsImlhdCI6MTc1ODA1MTIzNiwic3ViIjoiZGV2ZWxvcGVyLzY5MzY3ODE2LTM2YjctYTMzYy0zNzY5LTE5NmMyNDcyYTc3MSIsInNjb3BlcyI6WyJyb3lhbGUiXSwibGltaXRzIjpbeyJ0aWVyIjoiZGV2ZWxvcGVyL3NpbHZlciIsInR5cGUiOiJ0aHJvdHRsaW5nIn0seyJjaWRycyI6WyIxOTguMTg5LjI0OS43MyIsIjE3NC44NS45OS4xNjkiXSwidHlwZSI6ImNsaWVudCJ9XX0.7J0lte_XOk25woxuxAzBqrylSQcBVr2cSz4pD1Wr4f1-qAUvU4qlBpTDeq1ZJ3ZdweAzlaLAQHVLpQUiGQ4CpA";
+
+export default function PlayerScreen() {
+  const { tag: rawTag } = useLocalSearchParams<{ tag: string }>();
+  const tag = decodeURIComponent(rawTag ?? "");
+
+  const H = useMemo(
+    () => ({
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    }),
+    []
+  );
+
+  const [player, setPlayer] = useState<Player | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setErr(null);
+        const res = await fetch(
+          `https://api.clashroyale.com/v1/players/${encodeURIComponent(tag)}`,
+          { headers: H }
+        );
+        const txt = await res.text();
+        if (cancelled) return;
+        if (!res.ok) throw new Error(`HTTP ${res.status} – ${txt}`);
+        const json = JSON.parse(txt) as Player;
+        setPlayer(json);
+      } catch (e: any) {
+        if (!cancelled) setErr(String(e?.message || e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [H, tag]);
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Player" }} />
+      <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 24 }}>
+        {loading ? (
+          <View style={styles.center}>
+            <ActivityIndicator />
+            <Text style={styles.dim}>Loading…</Text>
+          </View>
+        ) : err ? (
+          <View style={styles.center}>
+            <Text style={styles.error}>Failed to load player</Text>
+            <Text style={styles.dim}>{err}</Text>
+          </View>
+        ) : !player ? (
+          <View style={styles.center}>
+            <Text style={styles.dim}>No data.</Text>
+          </View>
+        ) : (
+          <>
+            <Text style={styles.title}>{player.name || "Player"}</Text>
+            <Text style={styles.tag}>{player.tag}</Text>
+
+            <View style={styles.card}>
+              <Line label="Trophies" value={fmt(player.trophies)} />
+              <Line label="Best" value={fmt(player.bestTrophies)} />
+              <Line label="XP Level" value={fmt(player.expLevel)} />
+              <Line label="Arena" value={player.arena?.name} />
+              <Line label="Clan" value={player.clan?.name ?? "No clan"} />
+            </View>
+
+            <View style={styles.card}>
+              <Text style={styles.section}>League</Text>
+              <Text style={styles.line}>
+                Current: {fmt(player.leagueStatistics?.currentSeason?.trophies)}{" "}
+                (best {fmt(player.leagueStatistics?.currentSeason?.bestTrophies)})
+              </Text>
+              <Text style={styles.line}>
+                Previous {player.leagueStatistics?.previousSeason?.id ?? "—"}:{" "}
+                {fmt(player.leagueStatistics?.previousSeason?.trophies)} (best{" "}
+                {fmt(player.leagueStatistics?.previousSeason?.bestTrophies)})
+              </Text>
+              <Text style={styles.line}>
+                Best {player.leagueStatistics?.bestSeason?.id ?? "—"}:{" "}
+                {fmt(player.leagueStatistics?.bestSeason?.trophies)}
+              </Text>
+            </View>
+
+            {/* Current Deck images as grid */}
+            <View style={styles.card}>
+              <Text style={styles.section}>Current Deck</Text>
+
+              {player.currentDeck?.length ? (
+                <View style={styles.deckGrid}>
+                  {player.currentDeck.map((c) => {
+                    const uri =
+                      c.iconUrls?.evolutionMedium ||
+                      c.iconUrls?.medium ||
+                      undefined;
+                    return (
+                      <View style={styles.deckItem} key={c.id}>
+                        {uri ? (
+                          <Image
+                            source={{ uri }}
+                            style={styles.cardImage}
+                            resizeMode="contain"
+                          />
+                        ) : (
+                          <View style={[styles.cardImage, styles.cardImageFallback]}>
+                            <Text style={styles.cardImageFallbackText}>No Img</Text>
+                          </View>
+                        )}
+                        <Text style={styles.cardName} numberOfLines={1}>
+                          {c.name}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              ) : (
+                <Text style={styles.dim}>No deck available.</Text>
+              )}
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+function Line({ label, value }: { label: string; value?: string | number | null }) {
+  return (
+    <Text style={styles.line}>
+      <Text style={{ fontWeight: "700" }}>{label}:</Text> {value ?? "—"}
+    </Text>
+  );
+}
+
+function fmt(n?: number | null) {
+  return typeof n === "number" ? n.toLocaleString() : "—";
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  center: { padding: 24, alignItems: "center", justifyContent: "center" },
+  dim: { color: "#6B7280", marginTop: 8 },
+  error: { color: "#DC2626", fontWeight: "700" },
+
+  title: { fontSize: 34, fontWeight: "800", paddingHorizontal: 16, paddingTop: 12 },
+  tag: { color: "#6B7280", paddingHorizontal: 16, marginTop: 4, marginBottom: 12 },
+
+  card: {
+    backgroundColor: "#F3F4F6",
+    marginHorizontal: 12,
+    marginTop: 12,
+    padding: 14,
+    borderRadius: 14,
+  },
+  section: { fontSize: 18, fontWeight: "800", marginBottom: 8 },
+  line: { fontSize: 16, color: "#111827", marginTop: 4 },
+
+  // deck grid
+  deckGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    marginTop: 8,
+  },
+  deckItem: {
+    width: "23%", // ~4 per row
+    marginBottom: 16,
+    alignItems: "center",
+  },
+  cardImage: {
+    width: 72,
+    height: 72,
+    borderRadius: 10,
+    backgroundColor: "#fff",
+  },
+  cardImageFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#E5E7EB",
+  },
+  cardImageFallbackText: { color: "#6B7280", fontSize: 12 },
+  cardName: {
+    marginTop: 6,
+    fontSize: 12,
+    color: "#111827",
+    textAlign: "center",
+  },
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-picker/picker": "2.11.1",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -32,6 +33,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-picker-select": "^9.3.1",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -3071,6 +3073,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.1.tgz",
+      "integrity": "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -10615,6 +10630,19 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -12544,6 +12572,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-picker-select": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-picker-select/-/react-native-picker-select-9.3.1.tgz",
+      "integrity": "sha512-o621HcsKJfJkpYeP/PZQiZTKbf8W7FT08niLFL0v1pGkIQyak5IfzfinV2t+/l1vktGwAH2Tt29LrP/Hc5fk3A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isequal": "^4.5.0",
+        "lodash.isobject": "^3.0.2"
+      },
+      "peerDependencies": {
+        "@react-native-picker/picker": "^2.4.0"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-picker/picker": "2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -38,6 +39,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-picker-select": "^9.3.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",


### PR DESCRIPTION
Made two new screens, one that shows the top 50 players for whatever season the user decides on. **Note** the newest working season is for 2022-09, as the rest of the seasons do not work for the API endpoint. The other screen is a follow-up on the top 50 players that will show up once the user clicks on a player. 

I did install `npx expo install @react-native-picker/picker`, but you should be able to just run `npm install` to get any of the new dependencies  

Addresses issues: #12 and #11 
